### PR TITLE
Revert base to 6.9

### DIFF
--- a/io.github.rfrench3.scopebuddy-gui.yml
+++ b/io.github.rfrench3.scopebuddy-gui.yml
@@ -1,9 +1,9 @@
 id: io.github.rfrench3.scopebuddy-gui
 runtime: org.kde.Platform
-runtime-version: '6.10'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 base: io.qt.PySide.BaseApp
-base-version: '6.10'
+base-version: '6.9'
 command: scopebuddygui
 finish-args:
   - --share=ipc


### PR DESCRIPTION
For the past few days, the 6.10 PySide runtime has been broken. Until it is fixed, I will revert the application to runtime 6.9.