### PR TITLE
Update to v2.4.1, update back to runtime 6.10

### DIFF
--- a/io.github.rfrench3.scopebuddy-gui.yml
+++ b/io.github.rfrench3.scopebuddy-gui.yml
@@ -1,9 +1,9 @@
 id: io.github.rfrench3.scopebuddy-gui
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 base: io.qt.PySide.BaseApp
-base-version: '6.9'
+base-version: '6.10'
 command: scopebuddygui
 finish-args:
   - --share=ipc
@@ -24,7 +24,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/rfrench3/scopebuddy-gui.git
-        tag: v2.4.0
+        tag: v2.4.1
     build-commands:
       - mkdir -p /app/share/scopebuddygui
       - install -Dm755 src/main.py /app/bin/scopebuddygui


### PR DESCRIPTION
- fix a crash that occurs when any file in the AppID subdirectory does not end with .conf
- remove the steam checkbox (that flag is specifically intended for steam itself)